### PR TITLE
Fix issue with non-developers needing to install Sphinx

### DIFF
--- a/htmltag.py
+++ b/htmltag.py
@@ -6,8 +6,8 @@
 from __future__ import unicode_literals
 
 # Meta
-__version__ = '1.7'
-__version_info__ = (1, 7)
+__version__ = '1.8'
+__version_info__ = (1, 8)
 __license__ = "Apache 2.0"
 __author__ = 'Dan McDougall <daniel.mcdougall@liftoffsoftware.com>'
 

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,36 @@
+import os
 import htmltag
 
 try:
-    from distutils.core import setup
-except ImportError:
     from setuptools import setup
+    from setuptools import Command
+except ImportError:
+    from distutils.core import setup
+    from distutils.cmd import Command
+    
+# https://pyscaffold.org/en/latest/_modules/pyscaffold/integration.html
+def build_cmd_docs():
+    """Return Sphinx's BuildDoc if available otherwise a dummy command
 
-from sphinx.setup_command import BuildDoc
-cmdclass = {'build_sphinx': BuildDoc}
+    Returns:
+        :obj:`~distutils.cmd.Command`: command object
+    """
+    try:
+        from sphinx.setup_command import BuildDoc
+    except ImportError:
+        class NoSphinx(Command):
+            user_options = []
+
+            def initialize_options(self):
+                raise RuntimeError("Sphinx documentation is not installed, "
+                                   "run: pip install sphinx")
+
+        return NoSphinx
+    else:
+        return BuildDoc
+
+
+cmdclass = {'build_sphinx': build_cmd_docs()}
 
 setup(
     name="htmltag",


### PR DESCRIPTION
This allows people to `pip install` this library without having sphinx in their current Python site-packgaes